### PR TITLE
removes sqlite for mysql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,17 @@ jobs:
           command: |
             ssh-keyscan github.com > ~/.ssh/known_hosts
             git clone $CONFIG_REPO
-            cd ai-s3-authorizer-config
+            cd etda-config
             ./bin/generate_app
   test:
     docker:
       - image: cimg/ruby:2.7.5-browsers
+      - image: mysql:8
+        environment:
+          MYSQL_ROOT_PASSWORD: etda
+          MYSQL_USER: etda
+          MYSQL_PASSWORD: etda
+          MYSQL_DATABASE: explore
       - image: solr:8.11.1-slim
         command: [
           "/bin/bash",
@@ -70,6 +76,10 @@ jobs:
     environment:
       RAILS_ENV: test
       PARTNER: graduate
+      MYSQL_HOST: '127.0.0.1'
+      MYSQL_USER: root
+      MYSQL_PASSWORD: etda
+      MYSQL_DATABASE: etda
       SOLR_USERNAME: etda
       SOLR_PASSWORD: etda
       SOLR_COLLECTION: etda

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,6 +1,15 @@
 # Required configuration
 export PARTNER=graduate
 
+# MySQL Parameters
+# We should use root so we can create the test database
+export MYSQL_USER=root
+export MYSQL_PASSWORD=etda
+export MYSQL_DATABASE=explore
+# Change this to 127.0.0.1 if you are running rails outside of docker
+export MYSQL_HOST=mysql
+export MYSQL_LOCAL_PORT=3306
+
 # Solr Parameters
 export SOLR_USERNAME=etda
 export SOLR_PASSWORD=etda

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,7 @@ gem 'faker'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'mysql2'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     minitar (0.9)
     minitest (5.15.0)
     msgpack (1.5.2)
+    mysql2 (0.5.4)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -367,7 +368,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.3)
@@ -428,6 +428,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jquery-rails
+  mysql2
   niftany
   pry-byebug
   puma (~> 5.0)
@@ -440,7 +441,6 @@ DEPENDENCIES
   simplecov
   solr_wrapper (>= 0.3)
   sprockets-rails
-  sqlite3 (~> 1.4)
   stimulus-rails
   turbo-rails
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,21 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  username: <%= ENV.fetch("MYSQL_USER") { "root" }  %>
+  password: <%= ENV.fetch("MYSQL_PASSWORD") { "root" }  %>
+  host: <%= ENV.fetch("MYSQL_HOST") { "127.0.0.1" }  %>
+  database: <%= ENV.fetch("MYSQL_DATABASE") { "explore" } %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: <%= ENV.fetch("MYSQL_DATABASE") { "explore" } %>-test
 
 production:
   <<: *default
-  database: db/production.sqlite3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,17 @@
 version: '3.5'
 services:
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    ports:
+      - ${MYSQL_LOCAL_PORT:-3306}:3306
   solr:
     image: solr:8.11.1-slim
     restart: always
@@ -20,3 +32,4 @@ services:
       "solr -c && solr auth enable -credentials $$SOLR_USERNAME:$$SOLR_PASSWORD -z localhost:9983; solr stop && solr -c -f",]
 volumes:
   solr-data:
+  mysql-data:


### PR DESCRIPTION
- copy the Mysql section from `.envrc.example` into `.envrc`
- turn up mysql with docker-compose `docker-compose up -d`
- re-run migrations `bundle exec rails db:migrate`
- profit?

adds mysql2 gem, and by default uses mysql in database.yml. wires in CI, and sets up docker-compose