### PR TITLE
Allow filename input on fake_solr_document.  Changed display of file …

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -34,7 +34,7 @@ $theme-colors: (
   border-color: $light-gray;
   border-radius: 6px;
   color: $white;
-  display: flex;
+  display: block;
   flex: 1;
   height: auto;
   overflow: visible;

--- a/app/models/fake_solr_document.rb
+++ b/app/models/fake_solr_document.rb
@@ -13,6 +13,8 @@ class FakeSolrDocument
     middle_name = name.middle_name
     keywords = options[:keywords] || Faker::Hipster.words(number: 5)
     committee_member_name = name.name
+    file_names = options[:file_names] || ['thesis_1.pdf']
+    file_ids = Array.new(file_names.count) { Faker::Number.unique.within(range: 1..1000) }
     @doc = {
       "year_isi": Faker::Date.between(from: 5.years.ago, to: Date.today).year,
       "final_submission_files_uploaded_at_dtsi": Faker::Date.between(from: 5.years.ago, to: Date.today).rfc3339,
@@ -33,12 +35,8 @@ class FakeSolrDocument
       "read_access_group_ssim": [
         'public'
       ],
-      "final_submission_file_isim": [
-        Faker::Number.unique.within(range: 1..1000)
-      ],
-      "file_name_ssim": [
-        options[:file_name] || 'thesis_1.pdf'
-      ],
+      "final_submission_file_isim": file_ids,
+      "file_name_ssim": file_names,
       "author_name_tesi": name.name,
       "last_name_ssi": last_name,
       "last_name_tesi": last_name,

--- a/app/models/fake_solr_document.rb
+++ b/app/models/fake_solr_document.rb
@@ -37,7 +37,7 @@ class FakeSolrDocument
         Faker::Number.unique.within(range: 1..1000)
       ],
       "file_name_ssim": [
-        'thesis_1.pdf'
+        options[:file_name] || 'thesis_1.pdf'
       ],
       "author_name_tesi": name.name,
       "last_name_ssi": last_name,


### PR DESCRIPTION
…link to be a block to text is forced to wrap.

before:
![Screen Shot 2022-06-23 at 10 13 12 AM](https://user-images.githubusercontent.com/32677188/175320542-36eab05f-175f-4ec7-a2aa-d3d8d9ff48c9.png)

after:
![Screen Shot 2022-06-23 at 10 13 32 AM](https://user-images.githubusercontent.com/32677188/175320586-7132ed91-9e72-430f-b5fc-901f7c729eff.png)

