### PR TITLE
don't delete configset

### DIFF
--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -8,7 +8,6 @@ namespace :solr do
   task reset: :environment do
     conf = EtdaExplore::SolrAdmin.new
     conf.delete_collection
-    conf.delete_configset
 
     Rake::Task['solr:init'].invoke
   end


### PR DESCRIPTION
if another instance is using the configset, delete configset will fail and then init won't be invoked. we'll allow init to handle lifecycle of configsets