### PR TITLE
186 - Upgrade specific docker version for config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
         user: root
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: docker24
           docker_layer_caching: true
       - checkout
       - docker/check:


### PR DESCRIPTION
In circleCI, we need a newer version of remote_docker for the publish jobs to run.