### PR TITLE
186 - changes remote docker version to default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
         user: root
     steps:
       - setup_remote_docker:
-          version: docker24
+          version: default
           docker_layer_caching: true
       - checkout
       - docker/check:


### PR DESCRIPTION
Rather than a locked version of docker, the circleCi config now uses the default. This should keep us from having to make changes as often.