### PR TITLE
Restrict bot challenge to '/catalog' and only challenge if there are query params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from CanCan::AccessDenied, with: :access_denied
 
-  before_action do |controller|
-    BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller, immediate: true)
-  end
-
   def login
     session[:redirect_url] = home_or_original_path
     if current_user

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,10 @@ class CatalogController < ApplicationController
     redirect_to '/404'
   end
 
+  before_action do |controller|
+    BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller, immediate: true)
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -25,12 +25,16 @@ Rails.application.config.to_prepare do
 
   BotChallengePage::BotChallengePageController.bot_challenge_config.redirect_for_challenge = false
 
+  BotChallengePage::BotChallengePageController.bot_challenge_config.rate_limited_locations = [
+    '/catalog'
+  ]
+
   # How long will a challenge success exempt a session from further challenges?
   BotChallengePage::BotChallengePageController.bot_challenge_config.session_passed_good_for = 24.hours
   BotChallengePage::BotChallengePageController.bot_challenge_config.allow_exempt = ->(controller, _config) {
     # Does not challenge the user if they are not making a search (EG "About Page")
     # Does not challenge "Good Bots" – we have another layer of filters so Header containing "Bot" should be legit
-    !!(controller.request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
+    controller.request.query_parameters.blank? || !!(controller.request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
   }
 
   # Exempt some requests from bot challenge protection


### PR DESCRIPTION
The readiness probe was being blocked when deploying to the k8s cluster.  I restricted where the bot challenge is triggered to fix this.