### PR TITLE
284 download tokens

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -7,6 +7,7 @@ export AUTO_REMEDIATE_WEBHOOK_PATH="/webhooks/auto_remediate"
 export AUTO_REMEDIATE_WEBHOOK_TOKEN_GRADUATE=abc123
 export AUTO_REMEDIATE_WEBHOOK_TOKEN_HONORS=def456
 export AUTO_REMEDIATE_WEBHOOK_TOKEN_MILSCH=ghi789
+export REMEDIATE_TOKEN_TTL
 
 # MySQL Parameters
 # We should use root so we can create the test database

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -6,12 +6,12 @@ class FilesController < ApplicationController
   before_action :enforce_bot_challenge, only: :solr_download_final_submission
 
   def solr_download_final_submission
-    token = files_params[:download_token]
+    token = files_params[:remediate_token]
     file_id = files_params[:id]
     remediated = ActiveModel::Type::Boolean.new.cast(files_params[:remediated])
 
     should_remediate =
-      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && !remediated && valid_download_token?(token, file_id)
+      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && valid_remediate_token?(token, file_id)
     file_path = full_file_path(file_id, remediated)
     if file_path.nil?
       render plain: 'An Error has occurred', status: :internal_server_error
@@ -28,7 +28,7 @@ class FilesController < ApplicationController
   private
 
     def files_params
-      params.permit(:id, :remediated, :download_token)
+      params.permit(:id, :remediated, :remediate_token)
     end
 
     def current_ability
@@ -51,16 +51,16 @@ class FilesController < ApplicationController
       BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(self, immediate: true)
     end
 
-    def valid_download_token?(token, file_id)
+    def valid_remediate_token?(token, file_id)
       return false if token.nil? || token.blank?
 
-      token_file_id = download_token_verifier.verify(token, purpose: :download_request)
+      token_file_id = remediate_token_verifier.verify(token, purpose: :remediate_request)
       token_file_id.to_i == file_id.to_i
     rescue ActiveSupport::MessageVerifier::InvalidSignature
       false
     end
 
-    def download_token_verifier
-      Rails.application.message_verifier(:download_request_token)
+    def remediate_token_verifier
+      Rails.application.message_verifier(:remediate_request_token)
     end
 end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -6,14 +6,22 @@ class FilesController < ApplicationController
   before_action :enforce_bot_challenge, only: :solr_download_final_submission
 
   def solr_download_final_submission
-    file_path = full_file_path(params[:id], params[:remediated])
+    # return if the token is not valid
+    token = files_params[:download_token]
+    file_id = files_params[:id]
+    remediated = ActiveModel::Type::Boolean.new.cast(files_params[:remediated])
+
+    should_remediate =
+      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && !remediated && valid_download_token?(token, file_id)
+
+    file_path = full_file_path(file_id, remediated)
     if file_path.nil?
       render plain: 'An Error has occurred', status: :internal_server_error
     else
       authorize! :read, @doc
       # We can remove the feature flag when we are confident in the new feature's performance
-      if ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && params[:remediated] != true
-        AutoRemediateWebhookJob.perform_later(params[:id])
+      if should_remediate
+        AutoRemediateWebhookJob.perform_later(file_id)
       end
       send_file file_path, disposition: :inline
     end
@@ -21,23 +29,40 @@ class FilesController < ApplicationController
 
   private
 
+    def files_params
+      params.permit(:id, :remediated, :download_token)
+    end
+
     def current_ability
       @current_ability ||= FileDownloadAbility.new(current_user, @doc)
     end
 
-    def full_file_path(file_param_id, remediated)
+    def full_file_path(file_id, remediated)
       blacklight = Blacklight::Solr::Repository.new(CatalogController.blacklight_config)
       response = if remediated
-                   blacklight.search(q: "remediated_final_submission_file_isim:#{file_param_id}")
+                   blacklight.search(q: "remediated_final_submission_file_isim:#{file_id}")
                  else
-                   blacklight.search(q: "final_submission_file_isim:#{file_param_id}")
+                   blacklight.search(q: "final_submission_file_isim:#{file_id}")
                  end
       @doc = response.documents.first || nil
 
-      @doc.file_by_id(file_param_id.to_i, @doc.access_level.current_access_level, remediated)
+      @doc.file_by_id(file_id.to_i, @doc.access_level.current_access_level, remediated)
     end
 
     def enforce_bot_challenge
       BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(self, immediate: true)
+    end
+
+    def valid_download_token?(token, file_id)
+      return false if token.nil? || token.blank?
+
+      token_file_id = download_token_verifier.verify(token, purpose: :download_request)
+      token_file_id.to_i == file_id.to_i
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      false
+    end
+
+    def download_token_verifier
+      Rails.application.message_verifier(:download_request_token)
     end
 end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -6,14 +6,12 @@ class FilesController < ApplicationController
   before_action :enforce_bot_challenge, only: :solr_download_final_submission
 
   def solr_download_final_submission
-    # return if the token is not valid
     token = files_params[:download_token]
     file_id = files_params[:id]
     remediated = ActiveModel::Type::Boolean.new.cast(files_params[:remediated])
 
     should_remediate =
       ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && !remediated && valid_download_token?(token, file_id)
-
     file_path = full_file_path(file_id, remediated)
     if file_path.nil?
       render plain: 'An Error has occurred', status: :internal_server_error

--- a/app/helpers/blacklight_display_helper.rb
+++ b/app/helpers/blacklight_display_helper.rb
@@ -79,7 +79,7 @@ module BlacklightDisplayHelper
 
     def final_submission_links(document)
       document.final_submissions.map do |final_submission_id, name|
-        query_params = { remediated: 'false', download_token: download_token(final_submission_id) }
+        query_params = { remediated: 'false', remediate_token: remediate_token(final_submission_id) }
         should_show_modal = document.remediated_final_submissions.blank? && ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true'
         modal_trigger_options = if should_show_modal
                                   { toggle: 'modal',
@@ -110,16 +110,16 @@ module BlacklightDisplayHelper
       @this_user ||= current_or_guest_user
     end
 
-    def download_token(final_submission_id)
-      download_token_verifier.generate(
+    def remediate_token(final_submission_id)
+      remediate_token_verifier.generate(
         final_submission_id,
         # In seconds, default to 8 minutes
-        expires_in: ENV.fetch('DOWNLOAD_TOKEN_TTL', 480).to_i,
-        purpose: :download_request
+        expires_in: ENV.fetch('REMEDIATE_TOKEN_TTL', 480).to_i,
+        purpose: :remediate_request
       )
     end
 
-    def download_token_verifier
-      Rails.application.message_verifier(:download_request_token)
+    def remediate_token_verifier
+      Rails.application.message_verifier(:remediate_request_token)
     end
 end

--- a/app/helpers/blacklight_display_helper.rb
+++ b/app/helpers/blacklight_display_helper.rb
@@ -66,23 +66,27 @@ module BlacklightDisplayHelper
     end
 
     def remediated_final_submissions_links(document)
+      query_params = { remediated: 'true' }
       document.remediated_final_submissions.map do |remediated_final_submission_id, name|
         content_tag(:span,
                     link_to(tag.i(class: 'fa fa-download download-link-fa') + "Download #{name}",
-                            Rails.application.routes.url_helpers.remediated_final_submission_file_path(remediated_final_submission_id),
+                            Rails.application.routes.url_helpers.final_submission_file_path(
+                              remediated_final_submission_id, **query_params
+                            ),
                             data: { confirm: document.confirmation }, class: 'file-link form-control'))
       end
     end
 
     def final_submission_links(document)
       document.final_submissions.map do |final_submission_id, name|
+        query_params = { remediated: 'false', download_token: download_token(final_submission_id) }
         should_show_modal = document.remediated_final_submissions.blank? && ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true'
         modal_trigger_options = if should_show_modal
                                   { toggle: 'modal',
                                     target: "#downloadModal-#{final_submission_id}" }
                                 end
 
-        file_path = Rails.application.routes.url_helpers.final_submission_file_path(final_submission_id)
+        file_path = Rails.application.routes.url_helpers.final_submission_file_path(final_submission_id, **query_params)
         data_options = { confirm: document.confirmation }.merge(modal_trigger_options || {})
         link_content = content_tag(:span,
                                    link_to(tag.i(class: 'fa fa-download download-link-fa') + "Download #{name}",
@@ -104,5 +108,18 @@ module BlacklightDisplayHelper
 
     def this_user
       @this_user ||= current_or_guest_user
+    end
+
+    def download_token(final_submission_id)
+      download_token_verifier.generate(
+        final_submission_id,
+        # In seconds, default to 8 minutes
+        expires_in: ENV.fetch('DOWNLOAD_TOKEN_TTL', 480).to_i,
+        purpose: :download_request
+      )
+    end
+
+    def download_token_verifier
+      Rails.application.message_verifier(:download_request_token)
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,7 @@ Rails.application.routes.draw do
   end
 
   get '/about', to: 'application#about'
-  get '/files/final_submissions/:id', to: 'files#solr_download_final_submission', defaults: { remediated: false },
-                                      as: :final_submission_file
-  get 'files/remediated_final_submissions/:id', to: 'files#solr_download_final_submission',
-                                                defaults: { remediated: true }, as: :remediated_final_submission_file
+  get '/files/final_submissions/:id', to: 'files#solr_download_final_submission', as: :final_submission_file
 
   # Legacy Redirects
   get '/theses/approved/:access_level/:id_prefix-:id/(:all)',

--- a/spec/controller/files_controller_spec.rb
+++ b/spec/controller/files_controller_spec.rb
@@ -5,6 +5,13 @@ require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe FilesController, type: :controller do
+  let(:download_token_verifier) { Rails.application.message_verifier(:download_request_token) }
+  let(:doc) { FakeSolrDocument.new }
+  let(:file_id) { doc.doc[:final_submission_file_isim].first }
+  let(:download_token) do
+    download_token_verifier.generate(file_id, expires_in: 60, purpose: :download_request)
+  end
+
   before do
     allow(AutoRemediateWebhookJob).to receive(:perform_later)
   end
@@ -14,8 +21,6 @@ RSpec.describe FilesController, type: :controller do
   end
 
   context 'when open access' do
-    let(:doc) { FakeSolrDocument.new }
-
     before do
       doc.doc[:access_level_ss] = 'open_access'
       doc.doc[:final_submission_file_isim] = ['123']
@@ -30,7 +35,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'returns favorably' do
-      get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+      get :solr_download_final_submission, params: { id: file_id, download_token: }
       expect(response).to have_http_status(:ok)
     end
 
@@ -41,10 +46,24 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+        get :solr_download_final_submission, params: { id: file_id, download_token: }
         expect(AutoRemediateWebhookJob)
           .to have_received(:perform_later)
-          .with(doc.doc[:final_submission_file_isim].first)
+          .with(file_id)
+      end
+
+      it 'does not trigger the AutoRemediationJob if no download_token is provided' do
+        get :solr_download_final_submission, params: { id: file_id }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
+      end
+
+      it 'does not trigger the AutoRemediationJob if token does not match' do
+        get :solr_download_final_submission, params: { id: file_id, download_token: 'bogus-token' }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
       end
     end
 
@@ -55,17 +74,15 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+        get :solr_download_final_submission, params: { id: file_id, download_token: }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
-          .with(doc.doc[:final_submission_file_isim].first)
+          .with(file_id)
       end
     end
   end
 
   context 'when restricted to institution and logged out' do
-    let(:doc) { FakeSolrDocument.new }
-
     before do
       doc.doc[:access_level_ss] = 'restricted_to_institution'
       doc.doc[:final_submission_file_isim] = ['1234']
@@ -76,15 +93,13 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'raises an error' do
-      get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+      get :solr_download_final_submission, params: { id: file_id, download_token: }
       expect(response).to have_http_status(:unauthorized)
       expect(AutoRemediateWebhookJob).not_to have_received(:perform_later)
     end
   end
 
   context 'when restricted to institution and logged in' do
-    let(:doc) { FakeSolrDocument.new }
-
     before do
       doc.doc[:access_level_ss] = 'restricted_to_institution'
       doc.doc[:final_submission_file_isim] = ['1235']
@@ -99,7 +114,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'returns a 200 message' do
-      get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+      get :solr_download_final_submission, params: { id: file_id, download_token: }
       expect(response).to have_http_status(:ok)
     end
 
@@ -110,10 +125,24 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+        get :solr_download_final_submission, params: { id: file_id, download_token: }
         expect(AutoRemediateWebhookJob)
           .to have_received(:perform_later)
-          .with(doc.doc[:final_submission_file_isim].first)
+          .with(file_id)
+      end
+
+      it 'does not trigger the AutoRemediationJob if no download_token is provided' do
+        get :solr_download_final_submission, params: { id: file_id }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
+      end
+
+      it 'does not trigger the AutoRemediationJob if token does not match' do
+        get :solr_download_final_submission, params: { id: file_id, download_token: 'bogus-token' }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
       end
     end
 
@@ -124,17 +153,15 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+        get :solr_download_final_submission, params: { id: file_id, download_token: }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
-          .with(doc.doc[:final_submission_file_isim].first)
+          .with(file_id)
       end
     end
   end
 
   context 'when restricted' do
-    let(:doc) { FakeSolrDocument.new }
-
     before do
       doc.doc[:access_level_ss] = 'restricted'
       doc.doc[:final_submission_file_isim] = ['1236']
@@ -149,7 +176,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'throws a server error' do
-      get :solr_download_final_submission, params: { id: doc.doc[:final_submission_file_isim].first }
+      get :solr_download_final_submission, params: { id: file_id, download_token: }
       expect(response).to have_http_status(:internal_server_error)
       expect(AutoRemediateWebhookJob).not_to have_received(:perform_later)
     end

--- a/spec/controller/files_controller_spec.rb
+++ b/spec/controller/files_controller_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe FilesController, type: :controller do
-  let(:download_token_verifier) { Rails.application.message_verifier(:download_request_token) }
+  let(:remediate_token_verifier) { Rails.application.message_verifier(:remediate_request_token) }
   let(:doc) { FakeSolrDocument.new }
   let(:file_id) { doc.doc[:final_submission_file_isim].first }
-  let(:download_token) do
-    download_token_verifier.generate(file_id, expires_in: 60, purpose: :download_request)
+  let(:remediate_token) do
+    remediate_token_verifier.generate(file_id, expires_in: 60, purpose: :remediate_request)
   end
 
   before do
@@ -35,7 +35,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'returns favorably' do
-      get :solr_download_final_submission, params: { id: file_id, download_token: }
+      get :solr_download_final_submission, params: { id: file_id, remediate_token: }
       expect(response).to have_http_status(:ok)
     end
 
@@ -46,13 +46,13 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
         expect(AutoRemediateWebhookJob)
           .to have_received(:perform_later)
           .with(file_id)
       end
 
-      it 'does not trigger the AutoRemediationJob if no download_token is provided' do
+      it 'does not trigger the AutoRemediationJob if no remediate_token is provided' do
         get :solr_download_final_submission, params: { id: file_id }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
@@ -60,7 +60,7 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not trigger the AutoRemediationJob if token does not match' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: 'bogus-token' }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: 'bogus-token' }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
           .with(file_id)
@@ -74,7 +74,7 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
           .with(file_id)
@@ -93,7 +93,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'raises an error' do
-      get :solr_download_final_submission, params: { id: file_id, download_token: }
+      get :solr_download_final_submission, params: { id: file_id, remediate_token: }
       expect(response).to have_http_status(:unauthorized)
       expect(AutoRemediateWebhookJob).not_to have_received(:perform_later)
     end
@@ -114,7 +114,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'returns a 200 message' do
-      get :solr_download_final_submission, params: { id: file_id, download_token: }
+      get :solr_download_final_submission, params: { id: file_id, remediate_token: }
       expect(response).to have_http_status(:ok)
     end
 
@@ -125,13 +125,13 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
         expect(AutoRemediateWebhookJob)
           .to have_received(:perform_later)
           .with(file_id)
       end
 
-      it 'does not trigger the AutoRemediationJob if no download_token is provided' do
+      it 'does not trigger the AutoRemediationJob if no remediate_token is provided' do
         get :solr_download_final_submission, params: { id: file_id }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
@@ -139,7 +139,7 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not trigger the AutoRemediationJob if token does not match' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: 'bogus-token' }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: 'bogus-token' }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
           .with(file_id)
@@ -153,7 +153,7 @@ RSpec.describe FilesController, type: :controller do
       end
 
       it 'does not triggers the AutoRemediateWebhookJob' do
-        get :solr_download_final_submission, params: { id: file_id, download_token: }
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
         expect(AutoRemediateWebhookJob)
           .not_to have_received(:perform_later)
           .with(file_id)
@@ -176,7 +176,7 @@ RSpec.describe FilesController, type: :controller do
     end
 
     it 'throws a server error' do
-      get :solr_download_final_submission, params: { id: file_id, download_token: }
+      get :solr_download_final_submission, params: { id: file_id, remediate_token: }
       expect(response).to have_http_status(:internal_server_error)
       expect(AutoRemediateWebhookJob).not_to have_received(:perform_later)
     end

--- a/spec/helpers/blacklight_display_helper_spec.rb
+++ b/spec/helpers/blacklight_display_helper_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe BlacklightDisplayHelper do
         allow_any_instance_of(described_class).to receive(:this_user).and_return user
       end
 
+      it 'includes download_token for non-remediated files' do
+        expect(render_download_links(oa_doc_no_remediated)).to include 'download_token='
+        expect(render_download_links(oa_doc)).not_to include 'download_token='
+      end
+
+      it 'includes "remediated" as a query parameter' do
+        expect(render_download_links(oa_doc_no_remediated)).to include 'remediated=false'
+        expect(render_download_links(oa_doc)).to include 'remediated=true'
+      end
+
       context 'when ENABLE_ACCESSIBILITY_REMEDIATION is true' do
         before do
           @original_env_value = ENV.fetch('ENABLE_ACCESSIBILITY_REMEDIATION', nil)
@@ -93,8 +103,10 @@ RSpec.describe BlacklightDisplayHelper do
         end
 
         it 'returns a link for open access and restricted to institution submissions' do
-          expect(render_download_links(oa_doc)).to eq "<span><span><a class=\"file-link form-control\" href=\"/files/remediated_final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{oa_doc[:document][:remediated_file_name_ssim].first}</a></span></span>"
-          expect(render_download_links(rti_doc)).to eq "<span><span><a data-confirm=\"#{I18n.t('registered.confirmation')}\" class=\"file-link form-control\" href=\"/files/remediated_final_submissions/#{rti_doc[:document][:remediated_final_submission_file_isim].first}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{rti_doc[:document][:remediated_file_name_ssim].first}</a></span></span>"
+          expect(render_download_links(oa_doc)).to include "href=\"/files/final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}"
+          expect(render_download_links(oa_doc)).to include "Download #{oa_doc[:document][:remediated_file_name_ssim].first}</a></span></span>"
+          expect(render_download_links(rti_doc)).to include "href=\"/files/final_submissions/#{rti_doc[:document][:remediated_final_submission_file_isim].first}"
+          expect(render_download_links(rti_doc)).to include "Download #{rti_doc[:document][:remediated_file_name_ssim].first}"
           expect(render_download_links(r_doc)).to eq '<p>No files available due to restrictions.</p>'
         end
 
@@ -141,7 +153,8 @@ RSpec.describe BlacklightDisplayHelper do
         end
 
         it 'only returns a link for open access submissions' do
-          expect(render_download_links(oa_doc)).to eq "<span><span><a class=\"file-link form-control\" href=\"/files/remediated_final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{oa_doc[:document][:remediated_file_name_ssim].first}</a></span></span>"
+          expect(render_download_links(oa_doc)).to include "href=\"/files/final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}"
+          expect(render_download_links(oa_doc)).to include "Download #{oa_doc[:document][:remediated_file_name_ssim].first}"
           expect(render_download_links(rti_doc)).to eq '<span><a href="/login">Login to Download</a></span>'
           expect(render_download_links(r_doc)).to eq '<p>No files available due to restrictions.</p>'
         end
@@ -181,8 +194,11 @@ RSpec.describe BlacklightDisplayHelper do
       end
 
       it 'returns links for both remediated and final submission files' do
-        expect(render_download_links(oa_doc)).to include("<span><span><a class=\"file-link form-control\" href=\"/files/remediated_final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{oa_doc[:document][:remediated_file_name_ssim].first}</a></span>")
-        expect(render_download_links(oa_doc)).to include("<span><a class=\"file-link form-control\" href=\"/files/final_submissions/#{oa_doc[:document].final_submissions.key(oa_doc[:document][:file_name_ssim].first)}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{oa_doc[:document][:file_name_ssim].first}</a></span></span>")
+        links = render_download_links(oa_doc)
+        expect(links).to include("Download #{oa_doc[:document][:remediated_file_name_ssim].first}")
+        expect(links).to include("href=\"/files/final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}")
+        expect(links).to include("Download #{oa_doc[:document][:file_name_ssim].first}")
+        expect(links).to include("href=\"/files/final_submissions/#{oa_doc[:document][:final_submission_file_isim].first}")
       end
     end
 
@@ -193,7 +209,12 @@ RSpec.describe BlacklightDisplayHelper do
       end
 
       it 'returns link for remediated submission file only' do
-        expect(render_download_links(oa_doc)).to eq "<span><span><a class=\"file-link form-control\" href=\"/files/remediated_final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}\"><i class=\"fa fa-download download-link-fa\"></i>Download #{oa_doc[:document][:remediated_file_name_ssim].first}</a></span></span>"
+        links = render_download_links(oa_doc)
+        expect(links).to include "href=\"/files/final_submissions/#{oa_doc[:document][:remediated_final_submission_file_isim].first}"
+        expect(links).to include "Download #{oa_doc[:document][:remediated_file_name_ssim].first}"
+
+        expect(links).not_to include("Download #{oa_doc[:document][:file_name_ssim].first}")
+        expect(links).not_to include("href=\"/files/final_submissions/#{oa_doc[:document][:final_submission_file_isim].first}")
       end
     end
   end

--- a/spec/helpers/blacklight_display_helper_spec.rb
+++ b/spec/helpers/blacklight_display_helper_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe BlacklightDisplayHelper do
         allow_any_instance_of(described_class).to receive(:this_user).and_return user
       end
 
-      it 'includes download_token for non-remediated files' do
-        expect(render_download_links(oa_doc_no_remediated)).to include 'download_token='
-        expect(render_download_links(oa_doc)).not_to include 'download_token='
+      it 'includes remediate_token for non-remediated files' do
+        expect(render_download_links(oa_doc_no_remediated)).to include 'remediate_token='
+        expect(render_download_links(oa_doc)).not_to include 'remediate_token='
       end
 
       it 'includes "remediated" as a query parameter' do


### PR DESCRIPTION
closes #284 

Creates a token with the final submission links. Since the token is only used
at the moment to decide whether to run the autodownload process (disposition is always inline
with ETDA explore), we only need to generate a token for documents that have not yet been remediated.

Then checks for the token in the files controller. If the token is not present, or not a match, then it does not run the Remediation Process.