### PR TITLE
Hotfix health check

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,6 +239,8 @@ class CatalogController < ApplicationController
   private
 
     def enforce_bot_challenge
+      # Going to the front page also goes to index, and we only want this on searches
+      return if request.query_parameters.blank?
       BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(self, immediate: true)
     end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -241,6 +241,7 @@ class CatalogController < ApplicationController
     def enforce_bot_challenge
       # Going to the front page also goes to index, and we only want this on searches
       return if request.query_parameters.blank?
+
       BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(self, immediate: true)
     end
 end


### PR DESCRIPTION
Recently I removed logic that said not to run turnstile if
the request didn't have query params, as we want the download links
to go through turnstile. However, the healthchecks that hit '/' were
hitting the turnstile check and breaking. The solution is to reinstate
the query params logic but only for that particular end point that
points to CatalogController#index.