### PR TITLE
Allows PSU IPS to bypass cloudflare turnstile

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -8,6 +8,7 @@ export AUTO_REMEDIATE_WEBHOOK_TOKEN_GRADUATE=abc123
 export AUTO_REMEDIATE_WEBHOOK_TOKEN_HONORS=def456
 export AUTO_REMEDIATE_WEBHOOK_TOKEN_MILSCH=ghi789
 export REMEDIATE_TOKEN_TTL
+export BOT_CHALLENGE_IP_WHITELIST
 
 # MySQL Parameters
 # We should use root so we can create the test database

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -48,6 +48,13 @@ class FilesController < ApplicationController
     end
 
     def enforce_bot_challenge
+      # Challenge only if remote IP is not allowed
+      allowed_ips = ENV.fetch('BOT_CHALLENGE_IP_WHITELIST', '')
+        .split(',')
+        .filter_map { |ip| IPAddr.new(ip.strip) unless ip.strip.empty? }
+
+      return if allowed_ips.any? { |ip| ip.include?(IPAddr.new(request.remote_ip)) }
+
       BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(self, immediate: true)
     end
 

--- a/spec/controller/files_controller_spec.rb
+++ b/spec/controller/files_controller_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe FilesController, type: :controller do
   let(:remediate_token) do
     remediate_token_verifier.generate(file_id, expires_in: 60, purpose: :remediate_request)
   end
+  let(:allowed_ips) { '192.168.1.1' }
 
   before do
     allow(AutoRemediateWebhookJob).to receive(:perform_later)
+    allow(BotChallengePage::BotChallengePageController).to receive(:bot_challenge_enforce_filter)
+    ENV['BOT_CHALLENGE_IP_WHITELIST'] = allowed_ips
   end
 
   after do
     ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] = @original_env_value
+    ENV['BOT_CHALLENGE_IP_WHITELIST'] = nil
   end
 
   context 'when open access' do
@@ -37,6 +41,22 @@ RSpec.describe FilesController, type: :controller do
     it 'returns favorably' do
       get :solr_download_final_submission, params: { id: file_id, remediate_token: }
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'runs the bot_challenge_enforce filter' do
+      get :solr_download_final_submission, params: { id: file_id }
+      expect(BotChallengePage::BotChallengePageController).to have_received(:bot_challenge_enforce_filter)
+    end
+
+    context 'when the request comes from an allowed IP' do
+      before do
+        @request.remote_addr = allowed_ips
+      end
+
+      it 'bypasses the bot_challenge_enforce filter' do
+        get :solr_download_final_submission, params: { id: file_id }
+        expect(BotChallengePage::BotChallengePageController).not_to have_received(:bot_challenge_enforce_filter)
+      end
     end
 
     context 'when ENABLE_ACCESSIBILITY_REMEDIATION is true' do


### PR DESCRIPTION
Since the PDF API has to download the files from ETDA, we want to bypass the cf turnstile check so that the downloads don't get blocked.

According to Andrew, we can use the same list of IP ranges that Catalog uses.