### PR TITLE
1053 no remediate on bot download

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -11,7 +11,7 @@ class FilesController < ApplicationController
     remediated = ActiveModel::Type::Boolean.new.cast(files_params[:remediated])
 
     should_remediate =
-      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && valid_remediate_token?(token, file_id)
+      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && valid_remediate_token?(token, file_id) && !bot_request?
     file_path = full_file_path(file_id, remediated)
     if file_path.nil?
       render plain: 'An Error has occurred', status: :internal_server_error
@@ -68,5 +68,11 @@ class FilesController < ApplicationController
 
     def remediate_token_verifier
       Rails.application.message_verifier(:remediate_request_token)
+    end
+
+    # There are "good bots" that will get past cloudflare (Search Engines, etc)
+    # We want them to have access to the site but they should not trigger the remediation process on download
+    def bot_request?
+      !!(request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
     end
 end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -73,6 +73,6 @@ class FilesController < ApplicationController
     # There are "good bots" that will get past cloudflare (Search Engines, etc)
     # We want them to have access to the site but they should not trigger the remediation process on download
     def bot_request?
-      !!(request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
+      !!(request.headers['User-Agent'] =~ /bot/i)
     end
 end

--- a/spec/controller/files_controller_spec.rb
+++ b/spec/controller/files_controller_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe FilesController, type: :controller do
           .not_to have_received(:perform_later)
           .with(file_id)
       end
+
+      it 'does not trigger the AutoRemediationJob if the request was made by a bot' do
+        @request.headers['User-Agent'] = 'bingbot'
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
+      end
     end
 
     context 'when ENABLE_ACCESSIBILITY_REMEDIATION is not true' do


### PR DESCRIPTION
closes #1053

If the User-Agent header contains "bot" (as it does for googlebot and
bingbot), do not fire the remediation process upon download request.