### PR TITLE
299 - Adds Proquest to user-agents that skip cloudflare

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -11,7 +11,8 @@ class FilesController < ApplicationController
     remediated = ActiveModel::Type::Boolean.new.cast(files_params[:remediated])
 
     should_remediate =
-      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && valid_remediate_token?(token, file_id) && !bot_request?
+      ENV['ENABLE_ACCESSIBILITY_REMEDIATION'] == 'true' && valid_remediate_token?(token,
+                                                                                  file_id) && !user_agent_to_bypass?
     file_path = full_file_path(file_id, remediated)
     if file_path.nil?
       render plain: 'An Error has occurred', status: :internal_server_error
@@ -70,9 +71,9 @@ class FilesController < ApplicationController
       Rails.application.message_verifier(:remediate_request_token)
     end
 
-    # There are "good bots" that will get past cloudflare (Search Engines, etc)
-    # We want them to have access to the site but they should not trigger the remediation process on download
-    def bot_request?
-      !!(request.headers['User-Agent'] =~ /bot/i)
+    # Some user agents will bypass cloudflare but should not trigger the remediation process
+    # This include search engines Googlebot/Bingbot and Proquest Harvesting
+    def user_agent_to_bypass?
+      !!(request.headers['User-Agent'] =~ /bot|ProQuest Harvesting/i)
     end
 end

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -37,7 +37,7 @@ Rails.application.config.to_prepare do
     return true if controller.current_user.present? && !controller.current_user.guest?
 
     # Does not challenge "Good Bots" – we have another layer of filters so Header containing "Bot" should be legit
-    !!(controller.request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
+    !!(controller.request.headers['User-Agent'] =~ /bot|nagios-plugins|ProQuest Harvesting/i)
   }
 
   # Exempt some requests from bot challenge protection

--- a/spec/controller/files_controller_spec.rb
+++ b/spec/controller/files_controller_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe FilesController, type: :controller do
           .not_to have_received(:perform_later)
           .with(file_id)
       end
+
+      it 'does not trigger the AutoRemediationJob if the request was made by Proquest' do
+        @request.headers['User-Agent'] = 'Mozilla/5.0 ProQuest Harvesting'
+        get :solr_download_final_submission, params: { id: file_id, remediate_token: }
+        expect(AutoRemediateWebhookJob)
+          .not_to have_received(:perform_later)
+          .with(file_id)
+      end
     end
 
     context 'when ENABLE_ACCESSIBILITY_REMEDIATION is not true' do


### PR DESCRIPTION
closes #299

Also adds Proquest user agent to agents that skip pdf remediation.