### PR TITLE
Update image release process to include tagging and manifest deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,10 @@ jobs:
       - run:
           name: Tag & Release Image
           command: |
-            /usr/local/bin/image-release-for-clusters
+            export TRIGGERED_BY="$CIRCLE_USERNAME"
+            /usr/local/bin/image-tag
+            cd $CONFIG_REPO_NAME
+            /usr/local/bin/image-release-pr "clusters/ulprod/manifests/etda-workflow/prod.yaml"
   build-image:
     environment:
       REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>


### PR DESCRIPTION
This pull request updates the image release process in the `.circleci/config.yml` file. The main change is to split the tagging and release steps and to record the user who triggered the workflow.

**CI/CD Pipeline Improvements:**

* The image release step now exports the triggering user's name to the `TRIGGERED_BY` environment variable and separates the image tagging (`/usr/local/bin/image-tag`) from the release PR creation (`/usr/local/bin/image-release-pr`). It also changes directory to `$CONFIG_REPO_NAME` before creating the release PR.