### PR TITLE
Fix header title text overlap with PSU logo on smaller screens

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -13,9 +13,9 @@ $theme-colors: (
 
 .logo-title {
   a {
-    display: block;
     border-left: 1px solid $white;
     color: $white;
+    display: block;
     margin-left: 30px;
     padding-left: 1rem;
     padding-right: 0;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -13,6 +13,7 @@ $theme-colors: (
 
 .logo-title {
   a {
+    display: block;
     border-left: 1px solid $white;
     color: $white;
     margin-left: 30px;


### PR DESCRIPTION
## Summary
- Adds `display: block` to the `.logo-title` anchor in `custom.scss`
- Fixes text wrapping issue where the second line of the header title (e.g. "School") overlapped the PSU Libraries logo at ~1366px viewport widths

## Test plan
- [ ] Verify header title no longer overlaps the PSU logo at 100% zoom on a ~1366px wide screen
- [ ] Run `RAILS_ENV=test bundle exec rspec` — 118 examples, 0 failures

Closes #319