### PR TITLE
Fixes #317 Login to Download leads to a 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,20 @@ class ApplicationController < ActionController::Base
 
   layout :determine_layout if respond_to? :layout
 
+  # Store the location before authentication for later redirect
+  before_action :store_user_location!, if: :storable_location?
+
   rescue_from CanCan::AccessDenied, with: :access_denied
 
   def login
-    session[:redirect_url] = home_or_original_path
-    if current_user
-      redirect_to session[:redirect_url] || '/'
+    if current_user && !current_user.guest?
+      # Get the stored location or fall back to referer or home
+      redirect_path = stored_location_for(:user) || session[:user_return_to] || request.referer || '/'
+      # Clear the stored location
+      session.delete(:user_return_to) if session[:user_return_to]
+      redirect_to redirect_path, allow_other_host: false
     else
+      # If not authenticated, the ingress will redirect to OAuth2
       redirect_to login_path
     end
   end
@@ -21,10 +28,15 @@ class ApplicationController < ActionController::Base
 
   private
 
-    def home_or_original_path
-      return request.referer if request.referer
+    # Store the user's location for redirect after authentication
+    # Only store for GET requests that are not AJAX and not already auth-related
+    def storable_location?
+      request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && request.path != '/login'
+    end
 
-      '/'
+    def store_user_location!
+      # Store location for later redirect after authentication
+      store_location_for(:user, request.fullpath)
     end
 
     def access_denied

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -104,7 +104,9 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  # NOTE: We need session storage for http_header_authenticatable to work properly
+  # with redirects after OAuth2 authentication
+  config.skip_session_storage = []
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
 
   mount OkComputer::Engine, at: '/health'
 
-  get '/login', to: 'application#login', as: :login
+  authenticate :user do
+    get '/login', to: 'application#login', as: :login
+  end
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,7 @@ Rails.application.routes.draw do
 
   mount OkComputer::Engine, at: '/health'
 
-  authenticate :user do
-    get '/login', to: 'application#login', as: :login
-  end
+  get '/login', to: 'application#login', as: :login
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable


### PR DESCRIPTION
App is available to test here:  https://etda-p-authfix.uldev.k8s.libraries.psu.edu/

This pull request improves the authentication and redirect flow, ensuring users are redirected to their intended destination after logging in. It also updates session handling and route configuration to support these changes.

**Authentication and Redirect Improvements:**

* Added logic in `ApplicationController` to store the user's intended location before authentication and redirect them back after successful login, using `store_user_location!` and `stored_location_for(:user)` (`app/controllers/application_controller.rb`) [[1]](diffhunk://#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07R9-R22) [[2]](diffhunk://#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07L24-R39).
* Introduced `storable_location?` to determine when to store a location, ensuring redirects only occur for appropriate requests (`app/controllers/application_controller.rb`).

**Session and Devise Configuration:**

* Updated Devise initializer to always keep session storage enabled, which is necessary for proper redirect behavior after OAuth2 authentication (`config/initializers/devise.rb`).

**Routing Updates:**

* Moved the `/login` route outside of the `authenticate :user` block, making the login page accessible to unauthenticated users (`config/routes.rb`).